### PR TITLE
Add mode parameter to choose between quickpicklist and txt

### DIFF
--- a/src/EscargotDebugger.ts
+++ b/src/EscargotDebugger.ts
@@ -180,7 +180,7 @@ class EscargotDebugSession extends DebugSession {
       onScriptParsed: (data: EscargotMessageScriptParsed) => this.onScriptParsed(data),
       onError: (code: number, message: string) => this.onClose(),
       onOutput: (message: string, category?: string) => this.logOutput(message, category),
-      onWaitForSource: () => this.onWaitForSource()
+      onWaitForSource: () => this.onWaitForSource((<ILaunchRequestArguments>args).wait_for_source_mode)
     };
 
     this._protocolhandler = new EscargotDebugProtocolHandler(
@@ -521,11 +521,11 @@ class EscargotDebugSession extends DebugSession {
     this.handleSource(data);
   }
 
-  private async onWaitForSource(): Promise<void> {
+  private async onWaitForSource(mode?: string): Promise<void> {
     this.log('onWaitForSource', LOG_LEVEL.SESSION);
 
     if (this._sourceSendingOptions.state === SOURCE_SENDING_STATES.NOP) {
-      this.sendEvent(new Event('readSources'));
+      this.sendEvent(new Event('readSources', mode));
       this._sourceSendingOptions.state = SOURCE_SENDING_STATES.WAITING;
     } else if (this._sourceSendingOptions.state === SOURCE_SENDING_STATES.WAITING) {
       this.sendEvent(new Event('sendNextSource'));

--- a/src/EscargotDebuggerInterfaces.d.ts
+++ b/src/EscargotDebuggerInterfaces.d.ts
@@ -49,6 +49,8 @@ export interface ILaunchRequestArguments extends DebugProtocol.LaunchRequestArgu
   address: string;
   /** Debug port.*/
   port: number;
+  /** Execution mode if running multiple files. */
+  wait_for_source_mode?: string;
 }
 
 export interface SourceSendingOptions {


### PR DESCRIPTION
 **Add mode parameter to choose between quickpicklist and txt when running multiple files**

There are 3 modes available:

1. Running a single js file
2. Running multiple files with the quickpicklist selection (original solution)
3. Running multiple files with the txt list selection (new solution added in #14 )

___

1. Running a single js file:

Needs a similar launch.json file, assuming the file we would like to run is called "t.js" which is in our working directory.
```
{
  "version": "0.2.0",
  "configurations": [

    
    {
      "name": "Escargot.js: Launch",
      "type": "escargot",
      "request": "launch",
      "program": "/home/dabis/work/jerryscript/escargot/escargot",
      "address": "localhost",
      "localRoot": "${workspaceRoot}",
      "debugLog": 0,
      "args": [
        "--debugger-wait-source",
        "--start-debug-server",
        "./t.js"
    ]
    }
  ]
}
```

2. Running multiple files with the quickpicklist selection

Set the added "wait_for_source_mode" parameter to "quickpicklist"

```
{
  "version": "0.2.0",
  "configurations": [

    
    {
      "name": "Escargot.js: Launch",
      "type": "escargot",
      "request": "launch",
      "program": "/home/dabis/work/jerryscript/escargot/escargot",
      "address": "localhost",
      "localRoot": "${workspaceRoot}",
      "debugLog": 0,
      "wait_for_source_mode": "quickpicklist",
      "args": [
          "--start-debug-server",
          "--debugger-wait-source",
      ]
    }
  ]
}

```
3. Running multiple files with the txt list selection

Set the "wait_for_source_mode" parameter to the txt filename
```

{
  "version": "0.2.0",
  "configurations": [

    
    {
      "name": "Escargot.js: Launch",
      "type": "escargot",
      "request": "launch",
      "program": "/home/dabis/work/jerryscript/escargot/escargot",
      "address": "localhost",
      "localRoot": "${workspaceRoot}",
      "debugLog": 0,
      "wait_for_source_mode": "asd.txt",
      "args": [
          "--start-debug-server",
          "--debugger-wait-source",
      ]
    }
  ]
}
```

_Note: Set path to escargot as yours._

